### PR TITLE
Correct family and style data in name table.

### DIFF
--- a/scripts/lib/fontbuild/instanceNames.py
+++ b/scripts/lib/fontbuild/instanceNames.py
@@ -75,6 +75,7 @@ class InstanceNames:
             f.info.openTypeNamePreferredFamilyName = self.longfamily 
             f.info.openTypeNamePreferredSubfamilyName = self.longstyle 
         
+        f.info.openTypeOS2WeightClass = self._getWeightCode(self.weight)
         f.info.macintoshFONDName = re.sub(' ','',self.longfamily) + " " + re.sub(' ','',self.longstyle)
         f.info.postscriptFontName = f.info.macintoshFONDName.replace(" ", "-")
         if self.italic:

--- a/scripts/lib/fontbuild/instanceNames.py
+++ b/scripts/lib/fontbuild/instanceNames.py
@@ -76,6 +76,7 @@ class InstanceNames:
             f.info.openTypeNamePreferredSubfamilyName = self.longstyle 
         
         f.info.macintoshFONDName = re.sub(' ','',self.longfamily) + " " + re.sub(' ','',self.longstyle)
+        f.info.postscriptFontName = f.info.macintoshFONDName.replace(" ", "-")
         if self.italic:
             f.info.italicAngle = -12.0
         

--- a/scripts/lib/fontbuild/instanceNames.py
+++ b/scripts/lib/fontbuild/instanceNames.py
@@ -44,11 +44,10 @@ class InstanceNames:
         self.fullname =        "%s %s" %(self.longfamily, self.longstyle)
         self.postscript =      re.sub(' ','', self.longfamily) + "-" + re.sub(' ','',self.longstyle)
         
-        # if self.subfamilyAbbrev != "" and self.subfamilyAbbrev != None and self.subfamilyAbbrev != "Rg":
-        #     self.shortfamily = "%s %s" %(self.longfamily, self.subfamilyAbbrev)
-        # else:
-        #     self.shortfamily = self.longfamily
-        self.shortfamily = self.longfamily
+        if self.subfamilyAbbrev != "" and self.subfamilyAbbrev != None and self.subfamilyAbbrev != "Rg":
+            self.shortfamily = "%s %s" %(self.longfamily, self.longstyle.split()[0])
+        else:
+            self.shortfamily = self.longfamily
     
     def setRFNames(self,f, version=1, versionMinor=0):
         f.info.familyName = self.longfamily


### PR DESCRIPTION
This uncomments some code which distinguishes between Regular/Bold and other weights when setting the UFOs' styleMapFamilyName attribute, which is used by the FDK to set the output OTFs' family names (this association is documented here: http://unifiedfontobject.org/versions/ufo2/fontinfo.html). It's not clear why this code was commented out in the first place.

Part of #37