### PR TITLE
Don't convert mixed glyph values to ints.

### DIFF
--- a/scripts/lib/fontbuild/mix.py
+++ b/scripts/lib/fontbuild/mix.py
@@ -203,10 +203,10 @@ class FGlyph:
         return ng
     
     def _derefX(self,id):
-        return int(round(self.dataX[id]))
+        return self.dataX[id]
     
     def _derefY(self,id):
-        return int(round(self.dataY[id]))
+        return self.dataY[id]
     
     def addDiff(self,gB,gC):
         newGlyph = self + (gB - gC)


### PR DESCRIPTION
Doing this conversion visibly changes the appearance of some composite glyphs, since e.g. a component scale of 1.6 would be rounded to 2. What doesn't make sense is why this was working with FontLab....