### PR TITLE
Decompose nested components.

### DIFF
--- a/scripts/lib/fontbuild/decomposeGlyph.py
+++ b/scripts/lib/fontbuild/decomposeGlyph.py
@@ -3,10 +3,24 @@ def decomposeGlyph(font, glyphName):
 
     glyph = font[glyphName]
     for component in glyph.components:
-        componentGlyph = font[component.baseGlyph]
-        for contour in componentGlyph:
-            contour = contour.copy()
-            contour.scale(component.scale)
-            contour.move(component.offset)
-            glyph.appendContour(contour)
+        decompose(font, glyphName, component.baseGlyph,
+                  component.offset, component.scale)
     glyph.clear(contours=False, anchors=False, guides=False)
+
+
+def decompose(font, parentName, componentName, offset, scale):
+    """Copy contours to parent from component, including nested components."""
+
+    parent = font[parentName]
+    component = font[componentName]
+
+    for nested in component.components:
+        decompose(font, parentName, nested.baseGlyph,
+                  (offset[0] + nested.offset[0], offset[1] + nested.offset[1]),
+                  (scale[0] * nested.scale[0], scale[1] * nested.scale[1]))
+
+    for contour in component:
+        contour = contour.copy()
+        contour.scale(scale)
+        contour.move(offset)
+        parent.appendContour(contour)

--- a/scripts/lib/fontbuild/decomposeGlyph.py
+++ b/scripts/lib/fontbuild/decomposeGlyph.py
@@ -2,23 +2,20 @@ def decomposeGlyph(font, glyphName):
     """Moves the components of a glyph to its outline."""
 
     glyph = font[glyphName]
-    for component in glyph.components:
-        decompose(font, glyphName, component.baseGlyph,
-                  component.offset, component.scale)
-    glyph.clear(contours=False, anchors=False, guides=False)
+    decompose(font, glyph, glyph, (0, 0), (1, 1))
+    glyph.clearComponents()
 
 
-def decompose(font, parentName, componentName, offset, scale):
+def decompose(font, parent, component, offset, scale):
     """Copy contours to parent from component, including nested components."""
 
-    parent = font[parentName]
-    component = font[componentName]
-
     for nested in component.components:
-        decompose(font, parentName, nested.baseGlyph,
+        decompose(font, parent, font[nested.baseGlyph],
                   (offset[0] + nested.offset[0], offset[1] + nested.offset[1]),
                   (scale[0] * nested.scale[0], scale[1] * nested.scale[1]))
 
+    if component == parent:
+        return
     for contour in component:
         contour = contour.copy()
         contour.scale(scale)

--- a/scripts/lib/fontbuild/decomposeGlyph.py
+++ b/scripts/lib/fontbuild/decomposeGlyph.py
@@ -2,17 +2,18 @@ def decomposeGlyph(font, glyphName):
     """Moves the components of a glyph to its outline."""
 
     glyph = font[glyphName]
-    decompose(font, glyph, glyph, (0, 0), (1, 1))
+    deepCopyContours(font, glyph, glyph, (0, 0), (1, 1))
     glyph.clearComponents()
 
 
-def decompose(font, parent, component, offset, scale):
+def deepCopyContours(font, parent, component, offset, scale):
     """Copy contours to parent from component, including nested components."""
 
     for nested in component.components:
-        decompose(font, parent, font[nested.baseGlyph],
-                  (offset[0] + nested.offset[0], offset[1] + nested.offset[1]),
-                  (scale[0] * nested.scale[0], scale[1] * nested.scale[1]))
+        deepCopyContours(
+            font, parent, font[nested.baseGlyph],
+            (offset[0] + nested.offset[0], offset[1] + nested.offset[1]),
+            (scale[0] * nested.scale[0], scale[1] * nested.scale[1]))
 
     if component == parent:
         return


### PR DESCRIPTION
If components of components aren't also decomposed, we may miss some contours in the resulting glyphs.

This isn't actually an issue currently, but I was experimenting with decomposing every glyph and found that it could be. We do have glyphs with components which themselves have components, we just aren't normally decomposing these glyphs.