### PR TITLE
Fixed typographical error, changed availabe to available in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ TTF generation depends on:
 
 - FontForge (https://github.com/fontforge/fontforge)
 
-Whose Python interface should be availabe on Ubuntu by default via `apt-get
+Whose Python interface should be available on Ubuntu by default via `apt-get
 install fontforge python-fontforge`.
 
 ## Post-Production


### PR DESCRIPTION
google, I've corrected a typographical error in the documentation of the [roboto](https://github.com/google/roboto) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.