### PR TITLE
Provide a hotfix for webfont names

### DIFF
--- a/scripts/touchup_for_web.py
+++ b/scripts/touchup_for_web.py
@@ -47,9 +47,21 @@ def apply_web_specific_fixes(font, family_name):
         family_name += ' Condensed'
     full_name = family_name + ' ' + subfamily_name
 
-    # Family name
-    font_data.set_name_record(font, 1, family_name)
+    # macStyle
+    bold = subfamily_name.startswith(('Bold', 'Black'))
+    italic = subfamily_name.endswith('Italic')
+    macStyle = (italic << 1) | bold
+    font['head'].macStyle = macStyle
+
+    # Family, subfamily names
     font_data.set_name_record(font, 16, family_name)
+    style_map = ['Regular', 'Bold', 'Italic', 'Bold Italic']
+    if subfamily_name in style_map:
+        font_data.set_name_record(font, 1, family_name)
+    else:
+        weight = subfamily_name.split()[0]
+        font_data.set_name_record(font, 1, '%s %s' % (family_name, weight))
+        font_data.set_name_record(font, 2, style_map[macStyle])
 
     # Unique identifier and full name
     font_data.set_name_record(font, 3, full_name)


### PR DESCRIPTION
This ensures that we'll only have four fonts with family name "Roboto" (regular, bold, italic, and bold italic), which is necessary for Windows compatibility (see https://github.com/google/roboto/issues/37). Other styles have their weight appended to the family name.

Also ensures that the macStyle bold bit is set for weight Black, to be consistent with older Roboto binaries (see https://github.com/google/roboto/pull/111#issuecomment-143885330).