### PR TITLE
Further generalize common_tests.py

### DIFF
--- a/scripts/common_tests.py
+++ b/scripts/common_tests.py
@@ -29,7 +29,6 @@ from nototools import unicode_data
 import freetype
 
 import layout
-import roboto_data
 from glyph_area_pen import GlyphAreaPen
 
 
@@ -80,7 +79,7 @@ class TestItalicAngle(FontTest):
         for font in self.fonts:
             post_table = font['post']
             if 'Italic' in font_data.font_name(font):
-                expected_angle = -12.0
+                expected_angle = self.expected_italic_angle
             else:
                 expected_angle = 0.0
             self.assertEqual(post_table.italicAngle, expected_angle)
@@ -95,10 +94,8 @@ class TestMetaInfo(FontTest):
         _, self.fonts = self.loaded_fonts
 
     def test_mac_style(self):
-        """Tests the macStyle of the fonts to be correct.
+        """Tests the macStyle of the fonts to be correct."""
 
-        Bug: https://code.google.com/a/google.com/p/roboto/issues/detail?id=8
-        """
         for font in self.fonts:
             font_name = font_data.font_name(font)
             bold = ('Bold' in font_name) or (
@@ -108,19 +105,16 @@ class TestMetaInfo(FontTest):
             self.assertEqual(font['head'].macStyle, expected_mac_style)
 
     def test_fs_type(self):
-        """Tests the fsType of the fonts to be 0.
+        """Tests the fsType of the fonts."""
 
-        fsType of 0 marks the font free for installation, embedding, etc.
-
-        Bug: https://code.google.com/a/google.com/p/roboto/issues/detail?id=29
-        """
         for font in self.fonts:
-            self.assertEqual(font['OS/2'].fsType, 0)
+            self.assertEqual(font['OS/2'].fsType, self.expected_os2_fsType)
 
     def test_vendor_id(self):
-        """Tests the vendor ID of the fonts to be 'GOOG'."""
+        """Tests the vendor ID of the fonts."""
         for font in self.fonts:
-            self.assertEqual(font['OS/2'].achVendID, 'GOOG')
+            self.assertEqual(font['OS/2'].achVendID,
+                             self.expected_os2_achVendID)
 
     def test_us_weight(self):
         "Tests the usWeight of the fonts to be correct."""
@@ -134,15 +128,12 @@ class TestMetaInfo(FontTest):
     def test_version_numbers(self):
         "Tests the two version numbers of the font to be correct."""
         for font in self.fonts:
-            build_number = roboto_data.get_build_number()
-            expected_version = '2.' + build_number
             version = font_data.font_version(font)
             usable_part_of_version = version.split(';')[0]
-            self.assertEqual(usable_part_of_version,
-                             'Version ' + expected_version)
+            self.assertEqual(usable_part_of_version, self.expected_version)
 
             revision = font_data.printable_font_revision(font, accuracy=5)
-            self.assertEqual(revision, expected_version)
+            self.assertEqual(revision, self.expected_version)
 
 
 class TestNames(FontTest):
@@ -161,9 +152,7 @@ class TestNames(FontTest):
     def test_copyright(self):
         """Tests the copyright message."""
         for records in self.names:
-            self.assertEqual(
-                records[0],
-                'Copyright 2011 Google Inc. All Rights Reserved.')
+            self.assertEqual(records[0], self.expected_copyright)
 
     def parse_filename(self, filename):
         """Parse expected name attributes from filename."""
@@ -195,9 +184,7 @@ class TestNames(FontTest):
         return style
 
     def test_family_name(self):
-        """Tests the family name.
-        Bug: https://github.com/google/roboto/issues/37
-        """
+        """Tests the family name."""
 
         for font_file, records in zip(self.font_files, self.names):
 
@@ -216,9 +203,7 @@ class TestNames(FontTest):
                 self.assertEqual(records[1], family)
 
     def test_subfamily_name(self):
-        """Tests the subfamily name.
-        Bug: https://github.com/google/roboto/issues/37
-        """
+        """Tests the subfamily name."""
 
         for font_file, records in zip(self.font_files, self.names):
             _, weight, slope = self.parse_filename(font_file)
@@ -245,7 +230,7 @@ class TestNames(FontTest):
             family, weight, slope = self.parse_filename(font_file)
             style = self.build_style(weight, slope)
             expected_name = family + ' ' + style
-            self.assertEqual(records[3], expected_name)
+            self.assertEqual(records[3], self.expected_unique_id(expected_name))
             self.assertEqual(records[4], expected_name)
             self.assertFalse(records.has_key(18))
 

--- a/scripts/common_tests.py
+++ b/scripts/common_tests.py
@@ -130,7 +130,8 @@ class TestMetaInfo(FontTest):
         for font in self.fonts:
             version = font_data.font_version(font)
             usable_part_of_version = version.split(';')[0]
-            self.assertEqual(usable_part_of_version, self.expected_version)
+            self.assertEqual(usable_part_of_version,
+                             'Version ' + self.expected_version)
 
             revision = font_data.printable_font_revision(font, accuracy=5)
             self.assertEqual(revision, self.expected_version)

--- a/scripts/run_general_tests.py
+++ b/scripts/run_general_tests.py
@@ -21,6 +21,7 @@ import unittest
 from robofab.world import OpenFont
 
 import common_tests
+import roboto_data
 
 FONTS = common_tests.load_fonts(
     ['hinted/*.ttf'],
@@ -38,13 +39,23 @@ UFO_MASTERS = common_tests.load_fonts(
 
 class TestItalicAngle(common_tests.TestItalicAngle):
     loaded_fonts = FONTS
+    expected_italic_angle = -12.0
 
 
 class TestMetaInfo(common_tests.TestMetaInfo):
+    """Bugs:
+    https://code.google.com/a/google.com/p/roboto/issues/detail?id=8
+    https://code.google.com/a/google.com/p/roboto/issues/detail?id=29
+    """
+
     loaded_fonts = FONTS
     mark_heavier_as_bold = True
     test_us_weight = None
     test_version_numbers = None
+
+    # fsType of 0 marks the font free for installation, embedding, etc.
+    expected_os2_fsType = 0
+    expected_os2_achVendID = 'GOOG'
 
 
 class TestDigitWidths(common_tests.TestDigitWidths):

--- a/scripts/run_general_tests.py
+++ b/scripts/run_general_tests.py
@@ -51,6 +51,8 @@ class TestMetaInfo(common_tests.TestMetaInfo):
     loaded_fonts = FONTS
     mark_heavier_as_bold = True
     test_us_weight = None
+
+    #expected_version = 'Version 2.' + roboto_data.get_build_number()
     test_version_numbers = None
 
     # fsType of 0 marks the font free for installation, embedding, etc.

--- a/scripts/run_general_tests.py
+++ b/scripts/run_general_tests.py
@@ -52,7 +52,7 @@ class TestMetaInfo(common_tests.TestMetaInfo):
     mark_heavier_as_bold = True
     test_us_weight = None
 
-    #expected_version = 'Version 2.' + roboto_data.get_build_number()
+    #expected_version = '2.' + roboto_data.get_build_number()
     test_version_numbers = None
 
     # fsType of 0 marks the font free for installation, embedding, etc.

--- a/scripts/run_web_tests.py
+++ b/scripts/run_web_tests.py
@@ -28,20 +28,34 @@ FONTS = common_tests.load_fonts(
 
 class TestItalicAngle(common_tests.TestItalicAngle):
     loaded_fonts = FONTS
+    expected_italic_angle = -12.0
 
 
 class TestMetaInfo(common_tests.TestMetaInfo):
     loaded_fonts = FONTS
     mark_heavier_as_bold = True
+
     # Since different font files are hinted at different times, the actual
     # outlines differ slightly. So we are keeping the version numbers as a hint.
     test_version_numbers = None
 
+    # fsType of 0 marks the font free for installation, embedding, etc.
+    expected_os2_fsType = 0
+    expected_os2_achVendID = 'GOOG'
+
 
 class TestNames(common_tests.TestNames):
+    """Bugs:
+    https://github.com/google/roboto/issues/37
+    """
+
     loaded_fonts = FONTS
     family_name = 'Roboto'
     mark_heavier_as_bold = True
+    expected_copyright = 'Copyright 2011 Google Inc. All Rights Reserved.'
+
+    def expected_unique_id(self, full_name):
+        return full_name
 
 
 class TestDigitWidths(common_tests.TestDigitWidths):


### PR DESCRIPTION
There is still quite a bit of content in common_tests.py which is Roboto-specific, this finally moves everything to run_* scripts.