### PR TITLE
[README.md] modify instructions for installing booleanOperations

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,7 @@ cd ../feaTools
 sudo python setup.py install
 cd ../Cython-0.22
 sudo python setup.py install
-cd ../booleanOperations/cppWrapper
-sudo python setup.py build_ext --inplace
-cp pyClipper.so ../Lib/booleanOperations
-cd ..
+cd ../booleanOperations
 sudo python setup.py install
 cd ..
 ```


### PR DESCRIPTION
The current master/HEAD no longer requires to run two different setup.py scripts and manually copy the *.so module.

https://github.com/typemytype/booleanOperations/pull/6