### PR TITLE
Remove refs to buildnumber in touchup scripts

### DIFF
--- a/res/roboto.cfg
+++ b/res/roboto.cfg
@@ -3,7 +3,6 @@
 builddir: out
 foundry: Google
 version: 2.130
-buildnumberfile: res/buildnumber.txt
 
 [res]
 

--- a/scripts/roboto_data.py
+++ b/scripts/roboto_data.py
@@ -14,16 +14,18 @@
 
 """General module for Roboto-specific data and methods."""
 
+import ConfigParser
 import os
-from os import path
 import re
 
 
-def get_build_number():
-    """Returns the build number as a five-digit string."""
-    build_number_txt = path.join(
-        path.dirname(__file__), os.pardir, 'res', 'buildnumber.txt')
-    build_number = open(build_number_txt).read().strip()
-    assert re.match('[0-9]{5}', build_number)
-    return build_number
+def get_version_number():
+    """Returns the version number as a string."""
 
+    config_parser = ConfigParser.RawConfigParser()
+    config_file = os.path.join(
+        os.path.dirname(__file__), os.pardir, 'res', 'roboto.cfg')
+    config_parser.read(config_file)
+    version_number = config_parser.get('main', 'version')
+    assert re.match(r'[0-9]+\.[0-9]{3}', version_number)
+    return version_number

--- a/scripts/temporary_touchups.py
+++ b/scripts/temporary_touchups.py
@@ -40,10 +40,9 @@ def apply_temporary_fixes(font):
 
 
 def update_version_and_revision(font):
-    """Update version and revision numbers from buildnumber.txt."""
-    build_number = roboto_data.get_build_number()
-    version_number = '2.' + build_number
+    """Update version and revision numbers."""
+
+    version_number = roboto_data.get_version_number()
     version_record = 'Version %s; %d' % (version_number, date.today().year)
     font_data.set_name_record(font, 5, version_record)
     font['head'].fontRevision = float(version_number)
-

--- a/scripts/touchup_for_android.py
+++ b/scripts/touchup_for_android.py
@@ -16,25 +16,21 @@
 
 """Post-build changes for Roboto for Android."""
 
-import os
-from os import path
 import sys
 
 from fontTools import ttLib
 from nototools import font_data
 
+import roboto_data
+
 
 def apply_temporary_fixes(font):
-    """Apply some temporary fixes.
-    """
-    # Fix version number from buildnumber.txt
+    """Apply some temporary fixes."""
+
     from datetime import date
 
-    build_number_txt = path.join(
-        path.dirname(__file__), os.pardir, 'res', 'buildnumber.txt')
-    build_number = open(build_number_txt).read().strip()
-
-    version_record = 'Version 2.%s; %d' % (build_number, date.today().year)
+    version_number = roboto_data.get_version_number()
+    version_record = 'Version %s; %d' % (version_number, date.today().year)
 
     for record in font['name'].names:
         if record.nameID == 5:


### PR DESCRIPTION
Mistakenly left out of ea52110dac0c0c0a7b27c24107d428e16c505a6d, which
removed this file from the resource directory.

So it appears that the build number was in fact used here, though
older Roboto binaries that I've seen on Android use the version number
instead of the build number. It's somewhat mysterious. In any case,
keep using the version number.