### PR TITLE
Overhaul CrOS post-processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,14 @@ web:
 chromeos:
 	mkdir -p out/chromeos
 	for source in hinted/*.ttf; do \
+		basename=$$(basename $$source); \
+		case $$source in \
+			hinted/Roboto-*) unhinted=out/RobotoTTF/$$basename ;; \
+			*) unhinted=out/RobotoCondensedTTF/$$basename ;; \
+		esac; \
 		touched=$$(mktemp); \
 		final=out/chromeos/$$(basename $$source); \
-		python scripts/touchup_for_web.py $$source $$touched Roboto && \
+		python scripts/touchup_for_cros.py $$source $$unhinted $$touched Roboto && \
 		python $$HOME/noto/nototools/subset.py $$touched $$final && \
 		rm $$touched; \
 	done

--- a/scripts/temporary_touchups.py
+++ b/scripts/temporary_touchups.py
@@ -20,15 +20,18 @@ from nototools import noto_fonts
 
 import roboto_data
 
-def apply_temporary_fixes(font):
+def apply_temporary_fixes(font, is_for_cros=False):
     """Apply some temporary fixes."""
     # Fix usWeight:
     font_name = font_data.font_name(font)
     weight = noto_fonts.parse_weight(font_name)
     weight_number = noto_fonts.WEIGHTS[weight]
+    # Chrome OS wants Thin to have usWeightClass=100
+    if is_for_cros and weight == 'Thin':
+        weight_number = 100
     font['OS/2'].usWeightClass = weight_number
 
-    # Set ascent, descent, and lineGap values to Android K values
+    # Set ascent, descent, and lineGap values to Android K values.
     hhea = font['hhea']
     hhea.ascent = 1900
     hhea.descent = -500
@@ -41,7 +44,6 @@ def apply_temporary_fixes(font):
         font['head'].macStyle |= (1 << 0)
         font['OS/2'].fsSelection |= (1 << 5)
         font['OS/2'].fsSelection &= ~(1 << 6)
-
 
 def update_version_and_revision(font):
     """Update version and revision numbers."""

--- a/scripts/touchup_for_cros.py
+++ b/scripts/touchup_for_cros.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+#
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Post-build changes for Roboto to deploy on Google Chrome/Chromium OS"""
+
+import sys
+
+from fontTools import ttLib
+from nototools import font_data
+from touchup_for_web import apply_web_cros_common_fixes
+
+import temporary_touchups
+
+def drop_non_windows_name_records(font):
+    """Drop name records whose (PID,EID,Lang) != (3,1,0x409)"""
+    names = font['name'].names
+    records_to_drop = set()
+    for record_number, record in enumerate(names):
+        name_ids = (record.platformID, record.platEncID, record.langID)
+        if name_ids != (3, 1, 0x409):
+             records_to_drop.add(record_number)
+
+    # Taken from nototools/font_data.py
+    if records_to_drop:
+        font['name'].names = [
+            record for record_number, record in enumerate(names)
+            if record_number not in records_to_drop]
+
+def correct_font(source_name, unhinted_name, target_font_name, family_name):
+    """Corrects metrics and other meta information."""
+
+    font = ttLib.TTFont(source_name)
+    unhinted = ttLib.TTFont(unhinted_name)
+
+    apply_web_cros_common_fixes(font, unhinted, family_name)
+    temporary_touchups.apply_temporary_fixes(font, is_for_cros=True)
+    temporary_touchups.update_version_and_revision(font)
+    drop_non_windows_name_records(font)
+    font.save(target_font_name)
+
+def main(argv):
+    """Correct the font specified in the command line."""
+    correct_font(*argv[1:])
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/touchup_for_web.py
+++ b/scripts/touchup_for_web.py
@@ -33,7 +33,10 @@ def apply_web_specific_fixes(font, unhinted, family_name):
     os2.sTypoLineGap = 102
     os2.usWinAscent = 1946
     os2.usWinDescent = 512
+    apply_web_cros_common_fixes(font, unhinted, family_name)
 
+def apply_web_cros_common_fixes(font, unhinted, family_name):
+    """Apply fixes needed for web and CrOS targets"""
     subfamily_name = font_data.get_name_records(font)[2].encode('ASCII')
     assert(subfamily_name in
         ['Thin', 'Thin Italic',
@@ -115,6 +118,7 @@ def correct_font(source_name, unhinted_name, target_font_name, family_name):
     # correct for black weights and their bold bits will be set
     apply_web_specific_fixes(font, unhinted, family_name)
     temporary_touchups.apply_temporary_fixes(font)
+    temporary_touchups.update_version_and_revision(font)
     font.save(target_font_name)
 
 


### PR DESCRIPTION
* Add touchup_for_cros.py
  - Update version (name table) and revision (head)
  - Drop name table records other than for {pid=3,eid=1,langId=0x409}
  - Keep the source values of (2146,+-555) for sTypo{Ascender,Descender} and usWin{Ascent,Descent} in OS/2 instead of changing them to (1536,-512) and (1946,512), respectively. 
  - hhea.{ascent,descent} are rewritten to (1900,-500) to keep it compatible with the previous CrOS version and web/Android builds. 

* touch_up_web.py
  - apply_web_specific_fixes is split into 2 parts:
    apply_web_cros_common_fixes() and
    apply_web_specific_fixes()
  - Update version (name table) and revision (head)

* temporary_touchups.py
  - Add an optional 'is_for_cros' to apply_tempoary_fixes.
    When is_for_cros is True, usWeightClass is set to 100 for Thin.
    The latest release version of fontconfig on CrOS does not
    distinguish  Thin from Light when it's 250 for Thin.

* Makefile
  - Fix chromeos target

This will fix #182. It'll also fix #179 for CrOS builds. 