### PR TITLE
subset webfonts when running make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,11 @@ web:
 			hinted/Roboto-*) unhinted=out/RobotoTTF/$$basename ;; \
 			*) unhinted=out/RobotoCondensedTTF/$$basename ;; \
 		esac; \
-		final=out/web/$$basename; \
-		python scripts/touchup_for_web.py $$source $$unhinted $$final Roboto; \
-		if [[ $$? -ne 0 ]]; then exit 1; fi; \
+		touched=$$(mktemp); \
+		final=out/web/$$(basename $$source); \
+		python scripts/touchup_for_web.py $$source $$unhinted $$touched Roboto && \
+		python scripts/subset_for_web.py $$touched $$final && \
+		rm $$touched; \
 	done
 
 chromeos:

--- a/scripts/run_web_tests.py
+++ b/scripts/run_web_tests.py
@@ -102,10 +102,6 @@ class TestLigatures(run_general_tests.TestLigatures):
     loaded_fonts = FONTS
 
 
-class TestFeatures(run_general_tests.TestFeatures):
-    loaded_fonts = FONTS
-
-
 class TestGlyphBounds(run_general_tests.TestGlyphBounds):
     loaded_fonts = FONTS
 


### PR DESCRIPTION
When running `make web`, the Fontmake file didn't apply `subset_for_web.py`. The webfonts hosted at https://fonts.google.com/specimen/Roboto have been subsetted.

Unless anyone can point me to a set of webfonts which have the full character set, I think make should apply this.
