### PR TITLE
Requires Python 2, not 3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ virtualenv roboto-env
 source roboto-env/bin/activate
 ```
 
-Download and install the dependencies:
+Download and install the dependencies (currently requires Python 2, not 3):
 
 ```bash
 cd roboto


### PR DESCRIPTION
It appears that roboto dependencies currently require Python 2. In particular https://github.com/robofab-developers/robofab.git@62229c4ea33c324e698766d3700ca9a47efcdeb6 .


```
Collecting git+https://github.com/robofab-developers/robofab.git@62229c4ea33c324e698766d3700ca9a47efcdeb6 (from -r requirements.txt (line 11))
  Cloning https://github.com/robofab-developers/robofab.git (to 62229c4ea33c324e698766d3700ca9a47efcdeb6) to /tmp/pip-xnipby8r-build
  Could not find a tag or branch '62229c4ea33c324e698766d3700ca9a47efcdeb6', assuming commit.
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-xnipby8r-build/setup.py", line 15
        print "*** Warning: FontTools needs the numpy library for some operations, see:"
                                                                                       ^
    SyntaxError: Missing parentheses in call to 'print'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-xnipby8r-build/
```