### PR TITLE
Generate hinted fonts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ hinted:
 			src/hinted/Roboto-*) unhinted=out/RobotoTTF/$$basename ;; \
 			*) unhinted=out/RobotoCondensedTTF/$$basename ;; \
 		esac; \
-		final=out/hinted/$$(basename $$source); \
+		final=out/hinted/$$basename; \
 		python scripts/touchup_for_web.py $$source $$unhinted $$final Roboto; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,18 @@ web:
 		rm $$touched; \
 	done
 
+hinted:
+	mkdir -p out/hinted
+	for source in src/hinted/*.ttf; do \
+		basename=$$(basename $$source); \
+		case $$source in \
+			src/hinted/Roboto-*) unhinted=out/RobotoTTF/$$basename ;; \
+			*) unhinted=out/RobotoCondensedTTF/$$basename ;; \
+		esac; \
+		final=out/hinted/$$(basename $$source); \
+		python scripts/touchup_for_web.py $$source $$unhinted $$final Roboto; \
+	done
+
 chromeos:
 	mkdir -p out/chromeos
 	for source in src/hinted/*.ttf; do \


### PR DESCRIPTION
Previous tagged releases have included a hinted version of Roboto. This
version is generated by using `scripts/touchup_for_web.py` only.

For further information see #261

---

I'm fairly certain [touchup_for_web.py](https://github.com/google/roboto/blob/master/scripts/touchup_for_web.py) was used because the old [v2.136 hinted fonts](https://github.com/google/roboto/releases/tag/v2.136) have the same vertical metric values as this script sets. No other touchup script sets vertical metric values.

**v2.136 Roboto-Regular.ttf:**
```
hhea ascent: 1900
hhea descent: -500

OS/2 sTypoAscender: 1536
OS/2 sTypoDescender: -512
OS/2 sTypoLineGap: 102
OS/2 usWinAscent: 1946
OS/2 usWinDescent: 512
```

Values from [script](https://github.com/google/roboto/blob/master/scripts/touchup_for_web.py#L31-L40)
```
hhea = font['hhea']
hhea.ascent = 1900
hhea.descent = -500

os2 = font['OS/2']
os2.sTypoAscender = 1536
os2.sTypoDescender = -512
os2.sTypoLineGap = 102
os2.usWinAscent = 1946
os2.usWinDescent = 512
``