### PR TITLE
Removed kerning between uppercase L and singlequote

### DIFF
--- a/src/v2/Roboto-Bold.ufo/kerning.plist
+++ b/src/v2/Roboto-Bold.ufo/kerning.plist
@@ -1882,8 +1882,6 @@
     <integer>-71</integer>
     <key>A</key>
     <integer>23</integer>
-    <key>quotesingle</key>
-    <integer>-264</integer>
     <key>space</key>
     <integer>-30</integer>
   </dict>

--- a/src/v2/Roboto-Regular.ufo/kerning.plist
+++ b/src/v2/Roboto-Regular.ufo/kerning.plist
@@ -2087,8 +2087,6 @@
     <integer>-64</integer>
     <key>A</key>
     <integer>19</integer>
-    <key>quotesingle</key>
-    <integer>-288</integer>
   </dict>
   <key>K</key>
   <dict>

--- a/src/v2/Roboto-Thin.ufo/kerning.plist
+++ b/src/v2/Roboto-Thin.ufo/kerning.plist
@@ -1901,8 +1901,6 @@
     <integer>-65</integer>
     <key>A</key>
     <integer>19</integer>
-    <key>quotesingle</key>
-    <integer>-336</integer>
   </dict>
   <key>K</key>
   <dict>


### PR DESCRIPTION
This modification removes the negative kerning between uppercase L and singlequote.

This issue has been described and discussed in issue #195.

As a native French speaker, it feels better without the negative kerning.
It surprises me that I'm apparently the only one who was really annoyed by this.

Before
<img width="227" alt="capture d ecran 2017-11-08 a 15 19 55" src="https://user-images.githubusercontent.com/11441969/32554105-1075b37a-c499-11e7-9674-190cf49ab292.png">


After
<img width="227" alt="capture d ecran 2017-11-08 a 15 19 08" src="https://user-images.githubusercontent.com/11441969/32554109-13703b54-c499-11e7-8788-5bf09611e6d1.png">